### PR TITLE
Split linters into separate jobs (NO_JIRA)

### DIFF
--- a/.github/workflows/lint-ansible-role.yml
+++ b/.github/workflows/lint-ansible-role.yml
@@ -5,7 +5,8 @@ on: # yamllint disable-line rule:truthy
   - push
 
 jobs:
-  lint:
+  lint-ansible:
+    name: Lint Ansible role
     runs-on: ubuntu-latest
 
     steps:
@@ -27,6 +28,21 @@ jobs:
           level: info
           reporter: ${{ env.REVIEWDOG_REPORTER }}
 
+  lint-yaml:
+    name: Lint YAML
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check for GitHub token to determine reporter type
+        run: |
+          if [ -z "${{ secrets.REVIEWDOG_TOKEN }}" ]; then
+              echo "REVIEWDOG_REPORTER=local" >> $GITHUB_ENV
+          else
+              echo "REVIEWDOG_REPORTER=github-pr-review" >> $GITHUB_ENV
+          fi
+
       - name: Run yamllint
         uses: reviewdog/action-yamllint@v1
         with:
@@ -34,6 +50,21 @@ jobs:
           filter_mode: nofilter
           level: info
           reporter: ${{ env.REVIEWDOG_REPORTER }}
+
+  lint-markdown:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check for GitHub token to determine reporter type
+        run: |
+          if [ -z "${{ secrets.REVIEWDOG_TOKEN }}" ]; then
+              echo "REVIEWDOG_REPORTER=local" >> $GITHUB_ENV
+          else
+              echo "REVIEWDOG_REPORTER=github-pr-review" >> $GITHUB_ENV
+          fi
 
       - name: Run markdownlint
         uses: reviewdog/action-markdownlint@v0


### PR DESCRIPTION
This allows them to run in parallel and won't stop later linters running if one fails.