### PR TITLE
Add yamllint exception to common_ccdc_status_checks

### DIFF
--- a/.github/workflows/common_ccdc_status_checks.yml
+++ b/.github/workflows/common_ccdc_status_checks.yml
@@ -5,7 +5,8 @@
 # To make changes persistent, please mark this repository with update_status_check: false
 # or make your changes in the github-repository-management/status_check.yml file
 name: Common CCDC PR Checks
-on: [pull_request]
+on:  # yamllint disable-line rule:truthy
+  - pull_request
 jobs:
   ccdc-commit-hooks-on-pull-request-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will stop lint tasks failing.